### PR TITLE
Accept Vec and slice arguments to encode_polyline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,8 @@ fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
     Ok(output)
 }
 
-/// Encodes a Google Encoded Polyline. Accepts a Vec or slice
+/// Encodes a Google Encoded Polyline. Accepts a slice,
+/// or anything (such as a Vec) that can deref to a slice.
 ///
 /// # Examples
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,17 +38,20 @@ fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
     Ok(output)
 }
 
-/// Encodes a Google Encoded Polyline.
+/// Encodes a Google Encoded Polyline. Accepts a Vec or slice
 ///
 /// # Examples
 ///
 /// ```
 /// use polyline;
 ///
-/// 	let coords = vec![[1.0, 2.0], [3.0, 4.0]];
-/// let encodedPolyline = polyline::encode_coordinates(&coords, 5);
+/// let coords_vec = vec![[1.0, 2.0], [3.0, 4.0]];
+/// let encoded_vec = polyline::encode_coordinates(&coords_vec, 5).unwrap();
+/// 
+/// let coords_slice = [[1.0, 2.0], [3.0, 4.0]];
+/// let encoded_slice = polyline::encode_coordinates(&coords_slice, 5).unwrap();
 /// ```
-pub fn encode_coordinates(coordinates: &Vec<[f64; 2]>, precision: u32) -> Result<String, String> {
+pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<String, String> {
     if coordinates.is_empty() {
         return Ok("".to_string());
     }


### PR DESCRIPTION
This is both more flexible and potentially more efficient, since slices require a single pointer dereference, and Vecs require two.

It also has the (potential) benefit of simplifying FFI interaction, since it's easier and more efficient to create slices than Vecs from pointers to data allocated outside Rust.