### PR TITLE
Address Clippy warnings, simplify loops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ keywords = ["polyline", "geo"]
 license = "ISC"
 
 [dependencies]
+rand = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "polyline"
 description = "Encoder and decoder for the Google Encoded Polyline format"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Tom MacWright <tom@macwright.org>"]
 repository = "https://github.com/georust/rust-polyline"
 readme = "README.md"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,14 @@
+#![feature(test)]
+extern crate test;
+use test::Bencher;
+extern crate polyline;
+use polyline::encode_coordinates;
+
+#[bench]
+#[allow(unused_must_use)]
+fn bench_threads(b: &mut Bencher) {
+    let res = vec![[38.5, -120.2], [40.7, -120.95], [430.252, -126.453]];
+    b.iter(||{
+        encode_coordinates(&res, 5);
+    });
+}

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -4,10 +4,18 @@ use test::Bencher;
 extern crate polyline;
 use polyline::encode_coordinates;
 
+extern crate rand;
+use rand::distributions::{IndependentSample, Range};
+
 #[bench]
 #[allow(unused_must_use)]
 fn bench_threads(b: &mut Bencher) {
-    let res = vec![[38.5, -120.2], [40.7, -120.95], [430.252, -126.453]];
+    let num_coords = 10000;
+    // These coordinates cover London, approximately
+    let between_lon = Range::new(-6.379880, 1.768960);
+    let between_lat = Range::new(49.871159, 55.811741);
+    let mut rng = rand::thread_rng();
+    let res = vec![[between_lat.ind_sample(&mut rng), between_lon.ind_sample(&mut rng)]; num_coords];
     b.iter(||{
         encode_coordinates(&res, 5);
     });

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -16,7 +16,7 @@ fn bench_threads(b: &mut Bencher) {
     let between_lat = Range::new(49.871159, 55.811741);
     let mut rng = rand::thread_rng();
     let res = vec![[between_lat.sample(&mut rng), between_lon.sample(&mut rng)]; num_coords];
-    b.iter(||{
+    b.iter(|| {
         encode_coordinates(&res, 5);
     });
 }

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -5,7 +5,7 @@ extern crate polyline;
 use polyline::encode_coordinates;
 
 extern crate rand;
-use rand::distributions::{IndependentSample, Range};
+use rand::distributions::{Distribution, Range};
 
 #[bench]
 #[allow(unused_must_use)]
@@ -15,7 +15,7 @@ fn bench_threads(b: &mut Bencher) {
     let between_lon = Range::new(-6.379880, 1.768960);
     let between_lat = Range::new(49.871159, 55.811741);
     let mut rng = rand::thread_rng();
-    let res = vec![[between_lat.ind_sample(&mut rng), between_lon.ind_sample(&mut rng)]; num_coords];
+    let res = vec![[between_lat.sample(&mut rng), between_lon.sample(&mut rng)]; num_coords];
     b.iter(||{
         encode_coordinates(&res, 5);
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,14 +100,19 @@ pub fn decode_polyline(polyline: &str, precision: u32) -> Result<Vec<[f64; 2]>, 
         let mut result = 0;
         let mut byte;
 
-        while {
-            let at_index = polyline.chars().nth(index).ok_or("Couldn't decode Polyline")?;
+        loop {
+            let at_index = polyline
+                .chars()
+                .nth(index)
+                .ok_or("Couldn't decode Polyline")?;
             byte = at_index as u64 - 63;
             index += 1;
             result |= (byte & 0x1f) << shift;
             shift += 5;
-            byte >= 0x20
-        } {}
+            if byte < 0x20 {
+                break;
+            }
+        }
 
         let latitude_change: i64 = if (result & 1) > 0 {
             !(result >> 1)
@@ -118,14 +123,19 @@ pub fn decode_polyline(polyline: &str, precision: u32) -> Result<Vec<[f64; 2]>, 
         shift = 0;
         result = 0;
 
-        while {
-            let at_index = polyline.chars().nth(index).ok_or("Couldn't decode Polyline")?;
+        loop {
+            let at_index = polyline
+                .chars()
+                .nth(index)
+                .ok_or("Couldn't decode Polyline")?;
             byte = at_index as u64 - 63;
             index += 1;
             result |= (byte & 0x1f) << shift;
             shift += 5;
-            byte >= 0x20
-        } {}
+            if byte < 0x20 {
+                break;
+            }
+        }
 
         let longitude_change: i64 = if (result & 1) > 0 {
             !(result >> 1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<St
 /// ```
 pub fn decode_polyline(polyline: &str, precision: u32) -> Result<Vec<[f64; 2]>, String> {
     let mut index = 0;
+    let mut at_index;
     let mut lat: i64 = 0;
     let mut lng: i64 = 0;
     let mut coordinates = vec![];
@@ -101,7 +102,7 @@ pub fn decode_polyline(polyline: &str, precision: u32) -> Result<Vec<[f64; 2]>, 
         let mut byte;
 
         loop {
-            let at_index = polyline
+            at_index = polyline
                 .chars()
                 .nth(index)
                 .ok_or("Couldn't decode Polyline")?;
@@ -124,7 +125,7 @@ pub fn decode_polyline(polyline: &str, precision: u32) -> Result<Vec<[f64; 2]>, 
         result = 0;
 
         loop {
-            let at_index = polyline
+            at_index = polyline
                 .chars()
                 .nth(index)
                 .ok_or("Couldn't decode Polyline")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<St
 ///
 /// let decodedPolyline = polyline::decode_polyline(&"_p~iF~ps|U_ulLnnqC_mqNvxq`@", 5);
 /// ```
-pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, String> {
+pub fn decode_polyline(polyline: &str, precision: u32) -> Result<Vec<[f64; 2]>, String> {
     let mut index = 0;
     let mut lat: i64 = 0;
     let mut lng: i64 = 0;
@@ -95,13 +95,13 @@ pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, Strin
     let base: i32 = 10;
     let factor = i64::from(base.pow(precision));
 
-    while index < str.len() {
+    while index < polyline.len() {
         let mut shift = 0;
         let mut result = 0;
         let mut byte;
 
         while {
-            let at_index = str.chars().nth(index).ok_or("Couldn't decode Polyline")?;
+            let at_index = polyline.chars().nth(index).ok_or("Couldn't decode Polyline")?;
             byte = at_index as u64 - 63;
             index += 1;
             result |= (byte & 0x1f) << shift;
@@ -119,7 +119,7 @@ pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, Strin
         result = 0;
 
         while {
-            let at_index = str.chars().nth(index).ok_or("Couldn't decode Polyline")?;
+            let at_index = polyline.chars().nth(index).ok_or("Couldn't decode Polyline")?;
             byte = at_index as u64 - 63;
             index += 1;
             result |= (byte & 0x1f) << shift;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ fn scale(n: f64, factor: i32) -> i64 {
 
 // Bounds checking for input values
 fn check<T>(to_check: T, bounds: (T, T)) -> Result<T, T>
-    where T: cmp::PartialOrd + Copy
+where
+    T: cmp::PartialOrd + Copy,
 {
     match to_check {
         to_check if bounds.0 <= to_check && to_check <= bounds.1 => Ok(to_check),
@@ -27,13 +28,15 @@ fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
     }
     let mut output: String = "".to_string();
     while coordinate >= 0x20 {
-        let from_char = try!(char::from_u32(((0x20 | (coordinate & 0x1f)) + 63) as u32)
-            .ok_or("Couldn't convert character"));
+        let from_char = try!(
+            char::from_u32(((0x20 | (coordinate & 0x1f)) + 63) as u32)
+                .ok_or("Couldn't convert character")
+        );
         output.push(from_char);
         coordinate >>= 5;
     }
-    let from_char = try!(char::from_u32((coordinate + 63) as u32)
-        .ok_or("Couldn't convert character"));
+    let from_char =
+        try!(char::from_u32((coordinate + 63) as u32).ok_or("Couldn't convert character"));
     output.push(from_char);
     Ok(output)
 }
@@ -48,7 +51,7 @@ fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
 ///
 /// let coords_vec = vec![[1.0, 2.0], [3.0, 4.0]];
 /// let encoded_vec = polyline::encode_coordinates(&coords_vec, 5).unwrap();
-/// 
+///
 /// let coords_slice = [[1.0, 2.0], [3.0, 4.0]];
 /// let encoded_slice = polyline::encode_coordinates(&coords_slice, 5).unwrap();
 /// ```
@@ -57,16 +60,20 @@ pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<St
         return Ok("".to_string());
     }
     for (i, pair) in coordinates.iter().enumerate() {
-        try!(check(pair[0], (MIN_LATITUDE, MAX_LATITUDE))
-            .map_err(|e| format!("Latitude error at position {0}: {1}", i, e).to_string()));
-        try!(check(pair[1], (MIN_LONGITUDE, MAX_LONGITUDE))
-            .map_err(|e| format!("Longitude error at position {0}: {1}", i, e).to_string()));
+        try!(
+            check(pair[0], (MIN_LATITUDE, MAX_LATITUDE))
+                .map_err(|e| format!("Latitude error at position {0}: {1}", i, e).to_string())
+        );
+        try!(
+            check(pair[1], (MIN_LONGITUDE, MAX_LONGITUDE))
+                .map_err(|e| format!("Longitude error at position {0}: {1}", i, e).to_string())
+        );
     }
     let base: i32 = 10;
     let factor: i32 = base.pow(precision);
 
-    let mut output = try!(encode(coordinates[0][0], 0.0, factor)) +
-                     &try!(encode(coordinates[0][1], 0.0, factor));
+    let mut output = try!(encode(coordinates[0][0], 0.0, factor))
+        + &try!(encode(coordinates[0][1], 0.0, factor));
 
     for (i, _) in coordinates.iter().enumerate().skip(1) {
         let a = coordinates[i];
@@ -76,7 +83,6 @@ pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<St
     }
     Ok(output)
 }
-
 
 /// Decodes a Google Encoded Polyline.
 ///
@@ -96,7 +102,6 @@ pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, Strin
     let factor = i64::from(base.pow(precision));
 
     while index < str.len() {
-
         let mut shift = 0;
         let mut result = 0;
         let mut byte;
@@ -108,8 +113,7 @@ pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, Strin
             result |= (byte & 0x1f) << shift;
             shift += 5;
             byte >= 0x20
-        } {
-        }
+        } {}
 
         let latitude_change: i64 = if (result & 1) > 0 {
             !(result >> 1)
@@ -127,8 +131,7 @@ pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, Strin
             result |= (byte & 0x1f) << shift;
             shift += 5;
             byte >= 0x20
-        } {
-        }
+        } {}
 
         let longitude_change: i64 = if (result & 1) > 0 {
             !(result >> 1)
@@ -148,8 +151,8 @@ pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, Strin
 #[cfg(test)]
 mod tests {
 
-    use super::encode_coordinates;
     use super::decode_polyline;
+    use super::encode_coordinates;
 
     struct TestCase {
         input: Vec<[f64; 2]>,
@@ -158,19 +161,25 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let test_cases = vec![TestCase {
-                                  input: vec![[1.0, 2.0], [3.0, 4.0]],
-                                  output: "_ibE_seK_seK_seK",
-                              },
-                              TestCase {
-                                  input: vec![[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
-                                  output: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
-                              }];
+        let test_cases = vec![
+            TestCase {
+                input: vec![[1.0, 2.0], [3.0, 4.0]],
+                output: "_ibE_seK_seK_seK",
+            },
+            TestCase {
+                input: vec![[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
+                output: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+            },
+        ];
         for test_case in test_cases {
-            assert_eq!(encode_coordinates(&test_case.input, 5).unwrap(),
-                       test_case.output);
-            assert_eq!(decode_polyline(&test_case.output, 5).unwrap(),
-                       test_case.input);
+            assert_eq!(
+                encode_coordinates(&test_case.input, 5).unwrap(),
+                test_case.output
+            );
+            assert_eq!(
+                decode_polyline(&test_case.output, 5).unwrap(),
+                test_case.input
+            );
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,15 +28,12 @@ fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
     }
     let mut output: String = "".to_string();
     while coordinate >= 0x20 {
-        let from_char = try!(
-            char::from_u32(((0x20 | (coordinate & 0x1f)) + 63) as u32)
-                .ok_or("Couldn't convert character")
-        );
+        let from_char = char::from_u32(((0x20 | (coordinate & 0x1f)) + 63) as u32)
+            .ok_or("Couldn't convert character")?;
         output.push(from_char);
         coordinate >>= 5;
     }
-    let from_char =
-        try!(char::from_u32((coordinate + 63) as u32).ok_or("Couldn't convert character"));
+    let from_char = char::from_u32((coordinate + 63) as u32).ok_or("Couldn't convert character")?;
     output.push(from_char);
     Ok(output)
 }
@@ -60,26 +57,23 @@ pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<St
         return Ok("".to_string());
     }
     for (i, pair) in coordinates.iter().enumerate() {
-        try!(
-            check(pair[0], (MIN_LATITUDE, MAX_LATITUDE))
-                .map_err(|e| format!("Latitude error at position {0}: {1}", i, e).to_string())
-        );
-        try!(
-            check(pair[1], (MIN_LONGITUDE, MAX_LONGITUDE))
-                .map_err(|e| format!("Longitude error at position {0}: {1}", i, e).to_string())
-        );
+        check(pair[0], (MIN_LATITUDE, MAX_LATITUDE))
+            .map_err(|e| format!("Latitude error at position {0}: {1}", i, e).to_string())?;
+
+        check(pair[1], (MIN_LONGITUDE, MAX_LONGITUDE))
+            .map_err(|e| format!("Longitude error at position {0}: {1}", i, e).to_string())?;
     }
     let base: i32 = 10;
     let factor: i32 = base.pow(precision);
 
-    let mut output = try!(encode(coordinates[0][0], 0.0, factor))
-        + &try!(encode(coordinates[0][1], 0.0, factor));
+    let mut output =
+        encode(coordinates[0][0], 0.0, factor)? + &encode(coordinates[0][1], 0.0, factor)?;
 
     for (i, _) in coordinates.iter().enumerate().skip(1) {
         let a = coordinates[i];
         let b = coordinates[i - 1];
-        output = output + &try!(encode(a[0], b[0], factor));
-        output = output + &try!(encode(a[1], b[1], factor));
+        output = output + &encode(a[0], b[0], factor)?;
+        output = output + &encode(a[1], b[1], factor)?;
     }
     Ok(output)
 }
@@ -107,7 +101,7 @@ pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, Strin
         let mut byte;
 
         while {
-            let at_index = try!(str.chars().nth(index).ok_or("Couldn't decode Polyline"));
+            let at_index = str.chars().nth(index).ok_or("Couldn't decode Polyline")?;
             byte = at_index as u64 - 63;
             index += 1;
             result |= (byte & 0x1f) << shift;
@@ -125,7 +119,7 @@ pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, Strin
         result = 0;
 
         while {
-            let at_index = try!(str.chars().nth(index).ok_or("Couldn't decode Polyline"));
+            let at_index = str.chars().nth(index).ok_or("Couldn't decode Polyline")?;
             byte = at_index as u64 - 63;
             index += 1;
             result |= (byte & 0x1f) << shift;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ const MIN_LATITUDE: f64 = -90.0;
 const MAX_LATITUDE: f64 = 90.0;
 
 fn scale(n: f64, factor: i32) -> i64 {
-    let scaled: f64 = n * (factor as f64);
+    let scaled = n * (f64::from(factor));
     scaled.round() as i64
 }
 
@@ -85,15 +85,15 @@ pub fn encode_coordinates(coordinates: &[[f64; 2]], precision: u32) -> Result<St
 /// ```
 /// use polyline;
 ///
-/// let decodedPolyline = polyline::decode_polyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@".to_string(), 5);
+/// let decodedPolyline = polyline::decode_polyline(&"_p~iF~ps|U_ulLnnqC_mqNvxq`@", 5);
 /// ```
-pub fn decode_polyline(str: String, precision: u32) -> Result<Vec<[f64; 2]>, String> {
+pub fn decode_polyline(str: &str, precision: u32) -> Result<Vec<[f64; 2]>, String> {
     let mut index = 0;
     let mut lat: i64 = 0;
     let mut lng: i64 = 0;
     let mut coordinates = vec![];
     let base: i32 = 10;
-    let factor: i64 = base.pow(precision) as i64;
+    let factor = i64::from(base.pow(precision));
 
     while index < str.len() {
 
@@ -169,7 +169,7 @@ mod tests {
         for test_case in test_cases {
             assert_eq!(encode_coordinates(&test_case.input, 5).unwrap(),
                        test_case.output);
-            assert_eq!(decode_polyline(test_case.output.to_string(), 5).unwrap(),
+            assert_eq!(decode_polyline(&test_case.output, 5).unwrap(),
                        test_case.input);
         }
     }
@@ -180,7 +180,7 @@ mod tests {
     fn broken_string() {
         let s = "_p~iF~ps|U_u🗑lLnnqC_mqNvxq`@";
         let res = vec![[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]];
-        assert_eq!(decode_polyline(s.to_string(), 5).unwrap(), res);
+        assert_eq!(decode_polyline(&s, 5).unwrap(), res);
     }
 
     #[test]
@@ -189,6 +189,6 @@ mod tests {
     fn bad_coords() {
         let s = "_p~iF~ps|U_ulLnnqC_mqNvxq`@";
         let res = vec![[38.5, -120.2], [40.7, -120.95], [430.252, -126.453]];
-        assert_eq!(encode_coordinates(&res, 5).unwrap(), s.to_string());
+        assert_eq!(encode_coordinates(&res, 5).unwrap(), s);
     }
 }


### PR DESCRIPTION
Addresses Clippy warnings concerning potentially lossy conversions, and replaces `String` with `&str` in `decode_polyline`, which makes for a more pleasant API.